### PR TITLE
Fixed the order of freeing used frames to avoid unknown errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='transphire',
-    version='1.2.5',
+    version='1.2.6',
     description='Automated post data aquisition processing tool',
     long_description=long_description,
     url='https://github.com/mstabrin/transphire',

--- a/transphire/processthread.py
+++ b/transphire/processthread.py
@@ -1287,14 +1287,6 @@ class ProcessThread(QThread):
             xml_file=xml_file
             )
 
-        self.shared_dict['typ'][self.content_settings['group']]['share_lock'].lock()
-        try:
-            self.shared_dict['share'][self.content_settings['group']].remove(root_name)
-        except IOError:
-            raise
-        finally:
-            self.shared_dict['typ'][self.content_settings['group']]['share_lock'].unlock()
-
         for aim in self.content_settings['aim']:
             *compare, aim_name = aim.split(':')
             var = True
@@ -1333,6 +1325,15 @@ class ProcessThread(QThread):
                     raise
         else:
             pass
+
+        self.shared_dict['typ'][self.content_settings['group']]['share_lock'].lock()
+        try:
+            self.shared_dict['share'][self.content_settings['group']].remove(root_name)
+        except IOError:
+            raise
+        finally:
+            self.shared_dict['typ'][self.content_settings['group']]['share_lock'].unlock()
+
 
     def already_in_translation_file(self, root_name):
         """


### PR DESCRIPTION
### Description of the Change

Moving the deletion of the original frames to the end of the function caused problems.
The name was freed from the already_found_list before, so the entries doubled.